### PR TITLE
Combined TransposeOp and MatmulOp

### DIFF
--- a/spartify/transforms/CMakeLists.txt
+++ b/spartify/transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_mlir_library(SpartifyPasses
   SpartifyConvertToSparse.cpp
   SpartifyGenericConversion.cpp
   SpartifyTileAndFuse.cpp
+  SpartifyConvertToTransposedMatmulOp.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}

--- a/spartify/transforms/SpartifyConvertToTransposedMatmulOp.cpp
+++ b/spartify/transforms/SpartifyConvertToTransposedMatmulOp.cpp
@@ -1,3 +1,4 @@
+#include "mlir/IR/PatternMatch.h"
 #include "spartify/transforms/passes.h"
 
 namespace mlir::spartify_compiler {
@@ -13,8 +14,58 @@ public:
 };
 } // namespace
 
-// ref:
-// https://github.com/iree-org/iree/blob/56ae9ce5a1f4278e8a07a55b709e1d90aaf9bb51/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp#L96-L108
+static SmallVector<NamedAttribute> getPrunedAttributeList(linalg::LinalgOp op) {
+  const StringLiteral memoAttr =
+      linalg::LinalgDialect::kMemoizedIndexingMapsAttrName;
+  SmallVector<NamedAttribute> prunedAttributeList;
+  for (auto attr : op->getDiscardableAttrs()) {
+    if (attr.getName() != memoAttr) {
+      prunedAttributeList.push_back(attr);
+    }
+  }
+  return prunedAttributeList;
+}
+
+LogicalResult
+insertTransposedMatmulOp(IRRewriter &rewriter,
+                         SmallVector<Operation *> &fuseableCandidate) {
+
+  const int size = fuseableCandidate.size();
+  if (fuseableCandidate.empty() || (size < 1))
+    return failure();
+
+  int count = 0;
+  for (Operation *op : fuseableCandidate) {
+
+    if (auto matmulOp = dyn_cast<linalg::MatmulOp>(op)) {
+      rewriter.setInsertionPointAfter(matmulOp);
+
+      int idx = (count == size) ? count : count - 1;
+      auto transposeOp = dyn_cast<linalg::GenericOp>(fuseableCandidate[idx]);
+      if (!transposeOp)
+        return failure();
+
+      SmallVector<NamedAttribute> attrs = getPrunedAttributeList(matmulOp);
+      SmallVector<Value> newInputs = matmulOp.getInputs();
+
+      newInputs[1] = transposeOp.getInputs()[0];
+      auto newOp = rewriter.replaceOpWithNewOp<linalg::MatmulTransposeBOp>(
+          matmulOp, matmulOp.getResultTypes(), newInputs,
+          matmulOp.getDpsInits(), attrs);
+
+      if (transposeOp->use_empty())
+        rewriter.eraseOp(transposeOp);
+
+      return success();
+    }
+    count++;
+  }
+
+  return failure();
+}
+
+// pattern for combining linalg.matmul and linalg.transpose to
+// linalg.linalg.matmul_transpose_b
 static bool isaTransposeOpInterface(linalg::LinalgOp linalgOp) {
   if (linalgOp.getNumParallelLoops() != linalgOp.getNumLoops())
     return false;
@@ -34,14 +85,21 @@ void SpartifyConvertToTransposedMatmulOp::runOnOperation() {
   if (!funcOp)
     return;
 
-  funcOp->walk([&](linalg::GenericOp op) {
-    if (isaTransposeOpInterface(op)) {
-      llvm::outs() << op->getName() << "\n";
+  SmallVector<Operation *> fuseableCandidate;
+  funcOp->walk([&](linalg::LinalgOp op) {
+    if (isaTransposeOpInterface(op) || isa<linalg::MatmulOp>(op)) {
+      fuseableCandidate.push_back(op.getOperation());
     }
   });
+
+  IRRewriter rewriter(&getContext());
+  if (failed(insertTransposedMatmulOp(rewriter, fuseableCandidate))) {
+    funcOp->emitError("failed to fuse transpose and matmul");
+    return signalPassFailure();
+  }
 }
 
 std::unique_ptr<Pass> createSpartifyConvertToTransposedMatmulOpPass() {
-    return std::make_unique<SpartifyConvertToTransposedMatmulOp>(); 
+  return std::make_unique<SpartifyConvertToTransposedMatmulOp>();
 }
 } // namespace mlir::spartify_compiler

--- a/spartify/transforms/SpartifyConvertToTransposedMatmulOp.cpp
+++ b/spartify/transforms/SpartifyConvertToTransposedMatmulOp.cpp
@@ -1,0 +1,47 @@
+#include "spartify/transforms/passes.h"
+
+namespace mlir::spartify_compiler {
+#define GEN_PASS_DEF_SPARTIFYCONVERTTOTRANSPOSEDMATMULOP
+#include "passes.h.inc"
+
+namespace {
+class SpartifyConvertToTransposedMatmulOp
+    : public impl::SpartifyConvertToTransposedMatmulOpBase<
+          SpartifyConvertToTransposedMatmulOp> {
+public:
+  void runOnOperation() override;
+};
+} // namespace
+
+// ref:
+// https://github.com/iree-org/iree/blob/56ae9ce5a1f4278e8a07a55b709e1d90aaf9bb51/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp#L96-L108
+static bool isaTransposeOpInterface(linalg::LinalgOp linalgOp) {
+  if (linalgOp.getNumParallelLoops() != linalgOp.getNumLoops())
+    return false;
+
+  if (linalgOp.getNumDpsInputs() != 1 || linalgOp.getNumDpsInits() != 1)
+    return false;
+  auto mapRange = linalgOp.getIndexingMapsArray();
+  if (mapRange.size() != 2 || !mapRange.front().isPermutation() ||
+      !mapRange.back().isPermutation() || mapRange.front() == mapRange.back()) {
+    return false;
+  }
+  return llvm::hasSingleElement(linalgOp.getBlock()->getOperations());
+}
+
+void SpartifyConvertToTransposedMatmulOp::runOnOperation() {
+  auto funcOp = getOperation();
+  if (!funcOp)
+    return;
+
+  funcOp->walk([&](linalg::GenericOp op) {
+    if (isaTransposeOpInterface(op)) {
+      llvm::outs() << op->getName() << "\n";
+    }
+  });
+}
+
+std::unique_ptr<Pass> createSpartifyConvertToTransposedMatmulOpPass() {
+    return std::make_unique<SpartifyConvertToTransposedMatmulOp>(); 
+}
+} // namespace mlir::spartify_compiler

--- a/spartify/transforms/SpartifyGenericConversion.cpp
+++ b/spartify/transforms/SpartifyGenericConversion.cpp
@@ -25,9 +25,8 @@ void SpartifyGenericConversion::runOnOperation() {
 
   SmallVector<linalg::LinalgOp> initalGenericCandidate;
   funcOp->walk([&](linalg::LinalgOp linalgOp) {
-    if (!linalg::isaContractionOpInterface(linalgOp) &&
-        !isa<linalg::MatmulOp>(linalgOp)) {
-      initalGenericCandidate.push_back(linalgOp); 
+    if (!isa<linalg::MatmulOp>(linalgOp) && !isa<linalg::GenericOp>(linalgOp)) {
+      initalGenericCandidate.push_back(linalgOp);
     }
   });
 

--- a/spartify/transforms/SpartifyTileAndFuse.cpp
+++ b/spartify/transforms/SpartifyTileAndFuse.cpp
@@ -17,7 +17,7 @@ auto anyTilableOp(func::FuncOp funcOp) {
   funcOp->walk([&](Operation *op) {
     if (auto tileInteraface = dyn_cast<TilingInterface>(op)) {
       tilable = true;
-      llvm::outs() << op->getName() << "\n";
+      // llvm::outs() << op->getName() << "\n";
     }
   });
 

--- a/spartify/transforms/passes.cpp
+++ b/spartify/transforms/passes.cpp
@@ -23,6 +23,7 @@ void spartifyCodegenPassPipeline(mlir::OpPassManager &pm,
   } else {
     pm.addNestedPass<func::FuncOp>(createSpartifyGenericConversionPass());
     pm.addNestedPass<func::FuncOp>(createSpartifyTileAndFusePass()); 
+    pm.addNestedPass<func::FuncOp>(createSpartifyConvertToTransposedMatmulOpPass()); 
   }
 }
 

--- a/spartify/transforms/passes.cpp
+++ b/spartify/transforms/passes.cpp
@@ -23,7 +23,12 @@ void spartifyCodegenPassPipeline(mlir::OpPassManager &pm,
   } else {
     pm.addNestedPass<func::FuncOp>(createSpartifyGenericConversionPass());
     pm.addNestedPass<func::FuncOp>(createSpartifyTileAndFusePass()); 
+
     pm.addNestedPass<func::FuncOp>(createSpartifyConvertToTransposedMatmulOpPass()); 
+    pm.addPass(mlir::createCanonicalizerPass());
+    pm.addPass(mlir::createCSEPass());
+
+    pm.addNestedPass<func::FuncOp>(createSpartifyGenericConversionPass()); 
   }
 }
 

--- a/spartify/transforms/passes.h
+++ b/spartify/transforms/passes.h
@@ -18,6 +18,7 @@ namespace mlir::spartify_compiler {
 std::unique_ptr<Pass> createSpartifyConvertToSparsePass();
 std::unique_ptr<Pass> createSpartifyGenericConversionPass(); 
 std::unique_ptr<Pass> createSpartifyTileAndFusePass(); 
+std::unique_ptr<Pass> createSpartifyConvertToTransposedMatmulOpPass(); 
 void spartifyCodegenPassPipeline(mlir::OpPassManager& pm, bool isSparse = true); 
 
 namespace {

--- a/spartify/transforms/passes.td
+++ b/spartify/transforms/passes.td
@@ -18,4 +18,9 @@ def SpartifyTileAndFuse : Pass<"spartify-tile-and-fuse", "func::FuncOp"> {
     let constructor = "mlir::spartify_compiler::createSpartifyTileAndFusePass()"; 
 }
 
+def SpartifyConvertToTransposedMatmulOp : Pass<"spartify-convert-transposed-matmul-op", "func::FuncOp"> {
+    let summary = "convert transpose & matmul op to transposedMatmulOp";
+    let constructor = "mlir::spartify_compiler::createSpartifyConvertToTransposedMatmulOpPass()"; 
+}
+
 #endif // SPARTIFY_TRANSFORMS_PASSES_TD


### PR DESCRIPTION
The PR includes the pattern for, 
1. combining linalg.matmul and linalg.generic (transpose) to for linalg.matmul_transpose_b 
2. post / pre generalization of named operation